### PR TITLE
Generating random file names so that parallel calls for Pyconcorde will work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 concorde.egg-info/
 
 
+/venv/

--- a/concorde/tsp.py
+++ b/concorde/tsp.py
@@ -48,7 +48,7 @@ class TSPSolver(object):
             name = uuid.uuid4().hex
         try:
             ccdir = tempfile.mkdtemp()
-            ccfile = os.path.join(ccdir,  'data.tsp')
+            ccfile = os.path.join(ccdir, 'data.tsp')
             with open(ccfile, 'w') as fp:
                 write_tsp_file(fp, xs, ys, norm, name)
             return cls.from_tspfile(ccfile)

--- a/concorde/tsp.py
+++ b/concorde/tsp.py
@@ -48,7 +48,8 @@ class TSPSolver(object):
             name = uuid.uuid4().hex
         try:
             ccdir = tempfile.mkdtemp()
-            ccfile = os.path.join(ccdir, 'data.tsp')
+            file_name = uuid.uuid4().hex
+            ccfile = os.path.join(ccdir, file_name + '.tsp')
             with open(ccfile, 'w') as fp:
                 write_tsp_file(fp, xs, ys, norm, name)
             return cls.from_tspfile(ccfile)

--- a/concorde/tsp.py
+++ b/concorde/tsp.py
@@ -48,8 +48,7 @@ class TSPSolver(object):
             name = uuid.uuid4().hex
         try:
             ccdir = tempfile.mkdtemp()
-            file_name = uuid.uuid4().hex
-            ccfile = os.path.join(ccdir, file_name + '.tsp')
+            ccfile = os.path.join(ccdir,  'data.tsp')
             with open(ccfile, 'w') as fp:
                 write_tsp_file(fp, xs, ys, norm, name)
             return cls.from_tspfile(ccfile)
@@ -75,8 +74,9 @@ class TSPSolver(object):
             return "TSPSolver with {} nodes".format(self._ncount)
 
     def solve(self, time_bound=-1, verbose=True, random_seed=0):
+        name = str(uuid.uuid4().hex)[0:9]
         res = _CCtsp_solve_dat(
-            self._ncount, self._data, "name",
+            self._ncount, self._data, name,
             time_bound, not verbose, random_seed
         )
         return ComputedTour(*res)


### PR DESCRIPTION
Added a UUID generator for the temporary file name, to take only the first 8 characters. This should be sufficient to generate a unique enough file name.

We want to generate such a unique file name so that the pyconcorde solver can be invoked in parallel. Current implementation will force the temporary file name to be "name", which is a problem if the solver is called in parallel.