### PR TITLE
Add build-system deps in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "numpy", "Cython"]


### PR DESCRIPTION
This allows to directly install with pip without needing "cmake" and "numpy" installed beforehand.