### PR TITLE
single line installation `pip` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then run
 	
 Or, alternatively, all in one line, run:
 
-	pip install git+https://github.com/jvkersch/pyconcorde
+	pip install -e git+https://github.com/jvkersch/pyconcorde
 		
 	
 This will download and build Concorde (and its dependency QSOpt) and then build

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Then run
 
 	pip install -e .
 	
+Or, alternatively, all in one line, run:
+
+	pip install git+https://github.com/jvkersch/pyconcorde
+		
+	
 This will download and build Concorde (and its dependency QSOpt) and then build
 PyConcorde. While this may take a few minutes, downloading Concorde only
 happens the first time the install script is run (unless you remove the `data`


### PR DESCRIPTION
Alternative single line installation `pip` command
```
pip install -e git+https://github.com/jvkersch/pyconcorde
```