### PR TITLE
FIX — Upgrade sources to https

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,13 @@ QSOPT_LOCATION = {
     },
     "Linux": {
         "x86_64": (
-            "http://www.math.uwaterloo.ca/~bico/qsopt/beta/codes/PIC/qsopt.PIC.a",
+            "https://www.math.uwaterloo.ca/~bico/qsopt/beta/codes/PIC/qsopt.PIC.a",
             "http://www.math.uwaterloo.ca/~bico/qsopt/beta/codes/PIC/qsopt.h",
         ),
     },
 }
 
-CONCORDE_SRC = "http://www.math.uwaterloo.ca/tsp/concorde/downloads/codes/src/co031219.tgz"  # noqa
+CONCORDE_SRC = "https://www.math.uwaterloo.ca/tsp/concorde/downloads/codes/src/co031219.tgz"  # noqa
 
 
 def _safe_makedirs(*paths):


### PR DESCRIPTION
Fix a 308 error code when building concorde. 

308 (permanent redirect) should not be an error, so a more robust fix is needed.

Tested on an ARM M1 Mac.