### PR TITLE
Adding ansi flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def build_concorde():
         print("building concorde")
         _run("tar xzvf concorde.tgz", "build")
 
-        cflags = "-fPIC -O2 -g"
+        cflags = "-fPIC -O2 -g -ansi"
 
         if platform.system().startswith("Darwin"):
             flags = "--host=darwin"


### PR DESCRIPTION
Concorde is written for ansi c so it ought to be compiled with this flag. Addresses #74.