### PR TITLE
Adding support for direct problem loading

### DIFF
--- a/concorde/_concorde.pyx
+++ b/concorde/_concorde.pyx
@@ -11,6 +11,7 @@ cdef extern from "concorde.h":
         double *x
         double *y
         double *z
+        int **adj
 
     struct CCrandstate:
         pass
@@ -70,6 +71,22 @@ cdef class _CCdatagroup:
         else:
             return np.array([])
 
+    @property
+    def adj(self):
+        cdef int[:, :] adj_data
+        if self.initialized and self.c_data.adj != NULL:
+            adj_data = np.zeros((self.ncount, self.ncount), dtype=np.int32)
+            for i in range(self.ncount):
+                for j in range(self.ncount):
+                    if i > j:
+                        adj_data[i, j] = self.c_data.adj[i][j]
+                    elif i < j:
+                        adj_data[i, j] = self.c_data.adj[j][i]
+                    else:
+                        adj_data[i, j] = 0
+            return np.asarray(adj_data)
+        else:
+            return np.array([[]], dtype=np.int32)
 
 def _CCutil_gettsplib(str fname):
     cdef int ncount, retval
@@ -94,11 +111,10 @@ def _CCutil_tri2dat(int ncount, int[::1] elen):
     retval = CCutil_tri2dat(ncount, &elen[0], &dat.c_data)
     if retval == 0:
         dat.initialized = True
-        assert dat.ncount == ncount
+        dat.ncount = ncount
         return ncount, dat
     else:
-        return -1, None
-    
+        return -1, None  
 
 def _CCtsp_solve_dat(
         int ncount, _CCdatagroup ingroup,

--- a/concorde/_concorde.pyx
+++ b/concorde/_concorde.pyx
@@ -17,6 +17,8 @@ cdef extern from "concorde.h":
 
     int CCutil_gettsplib(char *datname, int *ncount, CCdatagroup *dat)
 
+    int CCutil_tri2dat(int ncount, int *elen, CCdatagroup *dat)
+
     int CCtsp_solve_dat (int ncount, CCdatagroup *indat, int *in_tour,
         int *out_tour, double *in_val, double *optval, int *success,
         int *foundtour, char *name, double *timebound, int *hit_timebound,
@@ -83,6 +85,20 @@ def _CCutil_gettsplib(str fname):
     else:
         return -1, None
 
+def _CCutil_tri2dat(int ncount, int[::1] elen):
+    cdef int retval
+    cdef _CCdatagroup dat
+
+    dat = _CCdatagroup()
+
+    retval = CCutil_tri2dat(ncount, &elen[0], &dat.c_data)
+    if retval == 0:
+        dat.initialized = True
+        assert dat.ncount == ncount
+        return ncount, dat
+    else:
+        return -1, None
+    
 
 def _CCtsp_solve_dat(
         int ncount, _CCdatagroup ingroup,

--- a/concorde/concorde.py
+++ b/concorde/concorde.py
@@ -49,8 +49,7 @@ class Concorde:
             except subprocess.CalledProcessError as e:
                 raise ConcordeError() from e
 
-            solution = Solution.from_file(tmp / "problem.sol", output=res.stdout)
-            return solution
+            return Solution.from_file(tmp / "problem.sol", output=res.stdout)
 
 
 _PLATFORM_MAP = {
@@ -64,12 +63,10 @@ def find_concorde_binary():
     """Return location of concorde binary for the current platform."""
     project_dir = Path(__file__).parent.parent
     pyconcorde_binaries = project_dir / "external" / "pyconcorde-build" / "binaries"
-    if pyconcorde_binaries.exists():
-        # Git checkout, with pyconcorde-build as git subtree
-        location = _PLATFORM_MAP[(platform.system(), platform.machine())]
-        concorde_exe = pyconcorde_binaries / location / "concorde"
-    else:
+    if not pyconcorde_binaries.exists():
         # Not a Git checkout. Assume that we're working from a wheel, with a
         # platform-specific concorde located in the module.
-        concorde_exe = project_dir / "concorde" / "concorde"
-    return concorde_exe
+        return project_dir / "concorde" / "concorde"
+    # Git checkout, with pyconcorde-build as git subtree
+    location = _PLATFORM_MAP[(platform.system(), platform.machine())]
+    return pyconcorde_binaries / location / "concorde"

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ def build_concorde():
         print("building concorde")
         _run("tar xzvf concorde.tgz", "build")
 
-        cflags = "-fPIC -O3 -g"
+        cflags = "-fPIC -O3 -g -ansi"
 
         if platform.system().startswith("Darwin"):
             flags = "--host=darwin"

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ def build_concorde():
         print("building concorde")
         _run("tar xzvf concorde.tgz", "build")
 
-        cflags = "-fPIC -O3 -g -ansi"
+        cflags = "-fPIC -O1 -g -ansi"
 
         if platform.system().startswith("Darwin"):
             flags = "--host=darwin"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-""" setup command to build Concorde Cython wrappers.
+"""setup command to build Concorde Cython wrappers.
 
 By default, the setup script will download the QSOpt linear solver, and
 download and compile Concorde. If you have either one of these packages
@@ -13,6 +13,7 @@ not set these variables (and rely on the downloaded Concorde) or set
 both of them. Setting only one will not work as intended.
 
 """
+
 from __future__ import print_function
 
 import os
@@ -91,7 +92,7 @@ def build_concorde():
         print("building concorde")
         _run("tar xzvf concorde.tgz", "build")
 
-        cflags = "-fPIC -O2 -g"
+        cflags = "-fPIC -O3 -g"
 
         if platform.system().startswith("Darwin"):
             flags = "--host=darwin"
@@ -99,10 +100,7 @@ def build_concorde():
             flags = ""
 
         datadir = os.path.abspath("data")
-        cwd = (
-            'CFLAGS="{cflags}" ./configure --prefix {data} '
-            "--with-qsopt={data} {flags}"
-        ).format(cflags=cflags, data=datadir, flags=flags)
+        cwd = f'CFLAGS="{cflags}" LDFLAGS="-ld_classic" ./configure --prefix {datadir} --with-qsopt={datadir} {flags}'
 
         _run(cwd, "build/concorde")
         _run("make", "build/concorde")

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ def build_concorde():
             flags = ""
 
         datadir = os.path.abspath("data")
-        cwd = f'CFLAGS="{cflags}" LDFLAGS="-ld_classic" ./configure --prefix {datadir} --with-qsopt={datadir} {flags}'
+        cwd = f'CFLAGS="{cflags}" ./configure --prefix {datadir} --with-qsopt={datadir} {flags}'
 
         _run(cwd, "build/concorde")
         _run("make", "build/concorde")

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ def build_concorde():
         print("building concorde")
         _run("tar xzvf concorde.tgz", "build")
 
-        cflags = "-fPIC -O1 -g -ansi"
+        cflags = "-fPIC -O3 -g -ansi"
 
         if platform.system().startswith("Darwin"):
             flags = "--host=darwin"


### PR DESCRIPTION
Hey I had a use case where I needed to skip the file-saving step of the process and so I wrote this PR which allows one to leverage the `tri2dat` function of Concorde via this python module. 