### PR TITLE
Warn on small/large coordinates in TSPSolver.from_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ you want to have it added here, please open an issue.
 Technical Notes
 -------
 
+**Coordinate scaling:** Concorde computes distances using integer arithmetic.
+If your coordinates are small (e.g. in [0, 1]), distances between points will
+be rounded to 0, leading to incorrect results or crashes. Scale your
+coordinates up before passing them to the solver — for example, multiply by
+1e6. Similarly, very large coordinates (above 1e7) may cause integer overflow.
+See `examples/truncation_demo.py` for a demonstration.
+
 PyConcorde needs Concorde and QSOpt. Downloading and building these packages
 should happen automatically on Linux/Mac OS, but please file an issue if you
 experience any trouble during this step.

--- a/README.md
+++ b/README.md
@@ -120,11 +120,13 @@ Technical Notes
 -------
 
 **Coordinate scaling:** Concorde rounds all edge distances to the nearest
-integer. If your coordinates are small (e.g. in [0, 1]), distances between
-points will round to 0, leading to incorrect results or crashes. Scale your
-coordinates up before passing them to the solver — for example, multiply by
-1e6. Similarly, very large coordinates (above 1e7) may cause integer overflow.
-See `examples/truncation_demo.py` for a demonstration.
+integer, as required by the
+[TSPLIB specification](http://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/tsp95.pdf).
+If your coordinates are small (e.g. in [0, 1]), distances between points will
+round to 0, leading to incorrect results or crashes. Scale your coordinates up
+before passing them to the solver — for example, multiply by 1e6. Similarly,
+very large coordinates (above 1e7) may cause integer overflow. See
+`examples/truncation_demo.py` for a demonstration.
 
 PyConcorde needs Concorde and QSOpt. Downloading and building these packages
 should happen automatically on Linux/Mac OS, but please file an issue if you

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ you want to have it added here, please open an issue.
 Technical Notes
 -------
 
-**Coordinate scaling:** Concorde computes distances using integer arithmetic.
-If your coordinates are small (e.g. in [0, 1]), distances between points will
-be rounded to 0, leading to incorrect results or crashes. Scale your
+**Coordinate scaling:** Concorde rounds all edge distances to the nearest
+integer. If your coordinates are small (e.g. in [0, 1]), distances between
+points will round to 0, leading to incorrect results or crashes. Scale your
 coordinates up before passing them to the solver — for example, multiply by
 1e6. Similarly, very large coordinates (above 1e7) may cause integer overflow.
 See `examples/truncation_demo.py` for a demonstration.

--- a/concorde/tests/test_concorde_datagroup.py
+++ b/concorde/tests/test_concorde_datagroup.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy.testing as nptest
 
@@ -22,6 +23,30 @@ class TestTSPSolver(unittest.TestCase):
         self.assertEqual(datagroup._ncount, 3)
         nptest.assert_allclose(datagroup.x, xs)
         nptest.assert_allclose(datagroup.y, ys)
+
+    def test_from_data_warns_small_coordinates(self):
+        # Coordinates in [0, 1] get truncated to 0 by Concorde
+        xs = [0.1, 0.5, 0.9]
+        ys = [0.2, 0.6, 0.8]
+        with self.assertWarns(UserWarning) as ctx:
+            TSPSolver.from_data(xs, ys, "EUC_2D")
+        self.assertIn("[-1, 1]", str(ctx.warning))
+
+    def test_from_data_warns_large_coordinates(self):
+        # Large coordinates risk integer overflow in Concorde
+        xs = [1e8, 2e8, 3e8]
+        ys = [4e8, 5e8, 6e8]
+        with self.assertWarns(UserWarning) as ctx:
+            TSPSolver.from_data(xs, ys, "EUC_2D")
+        self.assertIn("1e7", str(ctx.warning))
+
+    def test_from_data_no_warning_normal_coordinates(self):
+        # Normal coordinates should not trigger any warning
+        xs = [100, 200, 300]
+        ys = [400, 500, 600]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            TSPSolver.from_data(xs, ys, "EUC_2D")
 
     def test_solve(self):
         # Given

--- a/concorde/tests/test_concorde_datagroup.py
+++ b/concorde/tests/test_concorde_datagroup.py
@@ -30,7 +30,7 @@ class TestTSPSolver(unittest.TestCase):
         ys = [0.2, 0.6, 0.8]
         with self.assertWarns(UserWarning) as ctx:
             TSPSolver.from_data(xs, ys, "EUC_2D")
-        self.assertIn("[-1, 1]", str(ctx.warning))
+        self.assertIn("rounds distances", str(ctx.warning))
 
     def test_from_data_warns_large_coordinates(self):
         # Large coordinates risk integer overflow in Concorde

--- a/concorde/tsp.py
+++ b/concorde/tsp.py
@@ -6,6 +6,9 @@ import os
 import shutil
 import tempfile
 import uuid
+import warnings
+
+import numpy as np
 
 from concorde._concorde import _CCutil_gettsplib, _CCtsp_solve_dat
 from concorde.util import write_tsp_file, EDGE_WEIGHT_TYPES
@@ -42,6 +45,27 @@ class TSPSolver(object):
                 "norm must be one of {} but got {!r}".format(
                     ", ".join(EDGE_WEIGHT_TYPES), norm
                 )
+            )
+
+        xs_arr, ys_arr = np.asarray(xs, dtype=float), np.asarray(ys, dtype=float)
+        max_abs = max(np.max(np.abs(xs_arr)), np.max(np.abs(ys_arr)))
+
+        if max_abs <= 1.0:
+            warnings.warn(
+                "All coordinates are in [-1, 1]. Concorde uses integer "
+                "distances internally, so small coordinates will be "
+                "truncated to 0. Consider scaling your coordinates "
+                "(e.g. multiply by 1e6).",
+                UserWarning,
+                stacklevel=2,
+            )
+        if max_abs > 1e7:
+            warnings.warn(
+                "Coordinates exceed 1e7. Large values may cause integer "
+                "overflow in Concorde, leading to incorrect results or "
+                "crashes. Consider scaling down.",
+                UserWarning,
+                stacklevel=2,
             )
 
         # TODO: properly figure out Concorde's CCdatagroup format and

--- a/concorde/tsp.py
+++ b/concorde/tsp.py
@@ -52,17 +52,18 @@ class TSPSolver(object):
 
         if max_abs <= 1.0:
             warnings.warn(
-                "All coordinates are in [-1, 1]. Concorde uses integer "
-                "distances internally, so small coordinates will be "
-                "truncated to 0. Consider scaling your coordinates "
-                "(e.g. multiply by 1e6).",
+                "All coordinates are in [-1, 1]. Concorde rounds "
+                "distances to the nearest integer, so distances "
+                "between nearby points will round to 0. Consider "
+                "scaling your coordinates (e.g. multiply by 1e6).",
                 UserWarning,
                 stacklevel=2,
             )
         if max_abs > 1e7:
             warnings.warn(
-                "Coordinates exceed 1e7. Large values may cause integer "
-                "overflow in Concorde, leading to incorrect results or "
+                "Coordinates exceed 1e7. Concorde rounds distances "
+                "to the nearest integer, and large values may cause "
+                "integer overflow, leading to incorrect results or "
                 "crashes. Consider scaling down.",
                 UserWarning,
                 stacklevel=2,

--- a/examples/truncation_demo.py
+++ b/examples/truncation_demo.py
@@ -1,0 +1,59 @@
+"""Demonstrate how Concorde truncates small coordinates.
+
+Concorde stores coordinates as doubles but computes rounded integer
+distances. When coordinates are in [0, 1], the rounded Euclidean
+distances between points become 0. This can even cause Concorde to
+crash (segfault), as seen in GitHub issues #33 and #35.
+
+We use 10 equally spaced points on the unit circle (roots of unity).
+The optimal tour visits them in order, and the exact tour length is
+10 * 2 * sin(pi/10) = 10 * 0.6180... = 6.180...
+"""
+import warnings
+
+import numpy as np
+
+from concorde.tsp import TSPSolver
+
+n = 10
+angles = np.linspace(0, 2 * np.pi, n, endpoint=False)
+xs = np.cos(angles)
+ys = np.sin(angles)
+
+# Exact optimal tour length: n * side length of regular n-gon
+side_length = 2 * np.sin(np.pi / n)
+exact_tour_length = n * side_length
+print(f"Exact optimal tour length: {exact_tour_length:.4f}")
+
+# --- Unscaled coordinates (on the unit circle) ---
+print("\n=== Unscaled coordinates (unit circle) ===")
+print("Sample pairwise distances between adjacent nodes:")
+for i in range(3):
+    j = (i + 1) % n
+    d = np.sqrt((xs[i] - xs[j])**2 + (ys[i] - ys[j])**2)
+    print(f"  Nodes {i}-{j}: {d:.4f} -> rounded to int: {round(d)}")
+print("  ... (all round to 1 or 0)")
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    solver = TSPSolver.from_data(xs, ys, "EUC_2D")
+    solution = solver.solve(verbose=False)
+
+print(f"Concorde optimal value: {solution.optimal_value}")
+print(f"Expected: {exact_tour_length:.4f}")
+print(f"--> Wrong! Distances are too small for integer arithmetic.")
+
+# --- Scaled coordinates ---
+scale = 1_000_000
+xs_scaled = xs * scale
+ys_scaled = ys * scale
+
+print(f"\n=== Scaled coordinates (x {scale}) ===")
+solver_scaled = TSPSolver.from_data(xs_scaled, ys_scaled, "EUC_2D")
+solution_scaled = solver_scaled.solve(verbose=False)
+
+expected_scaled = round(exact_tour_length * scale)
+print(f"Concorde optimal value: {solution_scaled.optimal_value}")
+print(f"Expected (approx): {expected_scaled}")
+print(f"Tour: {solution_scaled.tour}")
+print(f"--> Correct! Tour visits nodes in order around the circle.")


### PR DESCRIPTION
## Summary
- Emit `UserWarning` in `TSPSolver.from_data` when coordinates fall in [-1, 1] (integer truncation) or exceed 1e7 (overflow risk)
- Add demo script (`examples/truncation_demo.py`) showing how coordinates on the unit circle produce wrong results due to rounding

Addresses #29, #33, #35.

## Test plan
- [x] `test_from_data_warns_small_coordinates` — warning emitted for [0, 1] coords
- [x] `test_from_data_warns_large_coordinates` — warning emitted for 1e8 coords
- [x] `test_from_data_no_warning_normal_coordinates` — no warning for normal coords