### PR TITLE
Document Concorde segfault with 3-node instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ before passing them to the solver — for example, multiply by 1e6. Similarly,
 very large coordinates (above 1e7) may cause integer overflow. See
 `examples/truncation_demo.py` for a demonstration.
 
+**Minimum problem size:** Concorde crashes (segfault) on instances with fewer
+than 4 nodes. This is a bug in Concorde's internal solver, not a PyConcorde
+issue.
+
 PyConcorde needs Concorde and QSOpt. Downloading and building these packages
 should happen automatically on Linux/Mac OS, but please file an issue if you
 experience any trouble during this step.

--- a/examples/three_node_crash.py
+++ b/examples/three_node_crash.py
@@ -1,0 +1,22 @@
+"""Demonstrate that Concorde crashes (segfault) with 3 nodes.
+
+This is a bug in Concorde's internal LP/matching code, not a coordinate
+scaling issue. The coordinates here are well-scaled integers, but
+Concorde cannot handle the degenerate case of only 3 nodes.
+
+With 4 or more nodes, the same kind of input works fine.
+"""
+from concorde.tsp import TSPSolver
+
+# A simple triangle with well-scaled integer coordinates
+xs = [0, 1000, 500]
+ys = [0, 0, 866]
+
+print("Solving TSP with 3 nodes (expect crash)...")
+print(f"Coordinates: {list(zip(xs, ys))}")
+
+solver = TSPSolver.from_data(xs, ys, "EUC_2D")
+solution = solver.solve(verbose=False)
+
+# This line is never reached
+print(f"Tour: {solution.tour}")


### PR DESCRIPTION
## Summary
- Add `examples/three_node_crash.py` demonstrating that Concorde crashes (segfault, exit code 139) when given only 3 nodes, even with well-scaled integer coordinates
- This is a bug in Concorde's internal LP/matching code, not a coordinate issue — 4+ nodes works fine

## Context
Discovered while investigating issues #33 and #35 (segfaults). The 3-node crash is a separate root cause from the coordinate scaling problems addressed in PR #88.