### PR TITLE
feat: warn when GEO/GEOM norm used with non-geographic coordinates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ python -m unittest concorde.tests.test_concorde.TestConcorde.test_solve -v
 
 No separate lint or type-check tooling is configured.
 
+## Development Workflow
+
+Follow the red/green TDD pattern: always start by writing a failing test, verify it fails, then implement the fix and verify the test passes.
+
 Set `CONCORDE_DIR` and `QSOPT_DIR` environment variables to use pre-installed Concorde/QSOpt instead of downloading.
 
 ## Architecture

--- a/concorde/tests/test_concorde_datagroup.py
+++ b/concorde/tests/test_concorde_datagroup.py
@@ -48,6 +48,23 @@ class TestTSPSolver(unittest.TestCase):
             warnings.simplefilter("error")
             TSPSolver.from_data(xs, ys, "EUC_2D")
 
+    def test_from_data_warns_geo_norm_with_non_geographic_coordinates(self):
+        # Coordinates exceeding 180 don't look like lat/lon
+        xs = [1000, 2000, 3000]
+        ys = [4000, 5000, 6000]
+        with self.assertWarns(UserWarning) as ctx:
+            TSPSolver.from_data(xs, ys, "GEO")
+        self.assertIn("latitude/longitude", str(ctx.warning))
+        self.assertIn("EUC_2D", str(ctx.warning))
+
+    def test_from_data_no_warning_geo_norm_with_geographic_coordinates(self):
+        # Valid lat/lon values should not trigger the geo warning
+        xs = [48.8566, 40.7128, 35.6762]
+        ys = [2.3522, -74.0060, 139.6503]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            TSPSolver.from_data(xs, ys, "GEO")
+
     def test_solve(self):
         # Given
         fname = get_dataset_path("berlin52")

--- a/concorde/tsp.py
+++ b/concorde/tsp.py
@@ -69,6 +69,16 @@ class TSPSolver(object):
                 stacklevel=2,
             )
 
+        if norm in ("GEO", "GEOM"):
+            if np.any(np.abs(xs_arr) > 180) or np.any(np.abs(ys_arr) > 180):
+                warnings.warn(
+                    f"norm={norm!r} expects geographic coordinates "
+                    "(latitude/longitude) but values exceed 180. "
+                    "Consider using 'EUC_2D' for Euclidean distances.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
         # TODO: properly figure out Concorde's CCdatagroup format and
         # initialize this object directly instead of going via file.
         if name is None:


### PR DESCRIPTION
## Summary
- Warn when `GEO` or `GEOM` norm is used with coordinates exceeding 180, since these norms expect latitude/longitude values (addresses issues #27, #63)
- Add tests for the geographic norm validation
- Add TDD workflow guidance to CLAUDE.md

## Test plan
- [x] `test_from_data_warns_geo_norm_with_non_geographic_coordinates` — verifies warning fires for non-geographic coords
- [x] `test_from_data_no_warning_geo_norm_with_geographic_coordinates` — verifies no warning for valid lat/lon